### PR TITLE
ReturnHelper Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,4 @@ paket-files/
 # Composer files
 composer.lock
 vendor/
+*.tmppica

--- a/Tests/Chain/ChainTest.php
+++ b/Tests/Chain/ChainTest.php
@@ -70,10 +70,12 @@
 			$isChainSuccessful = $chainHelper->traverse($dispatch);
 			$results           = $dispatch->getResults();
 
-			$this->assertTrue($isChainSuccessful);
-			$this->assertCount(1, $results);
-			$this->assertCount(3, $chainHelper->getNodeList());
-			$this->assertEquals(3, isset($results[0]['number']) ? $results[0]['number'] : 0);
+			self::assertTrue($isChainSuccessful);
+			self::assertCount(1, $results);
+			self::assertCount(3, $chainHelper->getNodeList());
+			self::assertEquals(3, isset($results[0]['number']) ? $results[0]['number'] : 0);
+
+			return;
 		}
 
 		public function test_dispatchCanBeConsumed() {
@@ -86,9 +88,11 @@
 			$chainHelper->traverse($dispatch);
 			$results = $dispatch->getResults();
 
-			$this->assertTrue($dispatch->isConsumable());
-			$this->assertTrue($dispatch->isConsumed());
-			$this->assertEquals(1, isset($results[0]['number']) ? $results[0]['number'] : 0);
+			self::assertTrue($dispatch->isConsumable());
+			self::assertTrue($dispatch->isConsumed());
+			self::assertEquals(1, isset($results[0]['number']) ? $results[0]['number'] : 0);
+
+			return;
 		}
 
 		public function test_dispatchHoldsStates() {
@@ -101,9 +105,11 @@
 			$chainHelper->traverse($dispatch);
 			$results = $dispatch->getResults();
 
-			$this->assertCount(3, $results);
-			$this->assertEquals(1, isset($results[0]['number']) ? $results[0]['number'] : 0);
-			$this->assertEquals(2, isset($results[1]['number']) ? $results[1]['number'] : 0);
-			$this->assertEquals(3, isset($results[2]['number']) ? $results[2]['number'] : 0);
+			self::assertCount(3, $results);
+			self::assertEquals(1, isset($results[0]['number']) ? $results[0]['number'] : 0);
+			self::assertEquals(2, isset($results[1]['number']) ? $results[1]['number'] : 0);
+			self::assertEquals(3, isset($results[2]['number']) ? $results[2]['number'] : 0);
+
+			return;
 		}
 	}

--- a/Tests/Chain/LoggingTest.php
+++ b/Tests/Chain/LoggingTest.php
@@ -70,10 +70,10 @@
 			$ch_norm = new ChainHelper();
 			$ch_consume = new ChainHelper(false, true);
 
-			$this->assertTrue($ch_nonevent->hookLogger(array($lg_nonevent, "receiveLog")));
-			$this->assertTrue($ch_event->hookLogger(array($lg_event, "receiveLog")));
-			$this->assertTrue($ch_norm->hookLogger(array($lg_norm, "receiveLog")));
-			$this->assertTrue($ch_consume->hookLogger(array($lg_consume, "receiveLog")));
+			self::assertTrue($ch_nonevent->hookLogger(array($lg_nonevent, "receiveLog")));
+			self::assertTrue($ch_event->hookLogger(array($lg_event, "receiveLog")));
+			self::assertTrue($ch_norm->hookLogger(array($lg_norm, "receiveLog")));
+			self::assertTrue($ch_consume->hookLogger(array($lg_consume, "receiveLog")));
 
 			$ch_nonevent->linkNode(new NonConsumeTestNode());
 			$ch_nonevent->linkNode(new ConsumeTestNode());
@@ -98,10 +98,10 @@
 			$ch_norm->traverse($disp);
 			$ch_consume->traverse($cdisp);
 
-			$this->assertEquals(4, count($lg_nonevent->_messages));
-			$this->assertEquals(3, count($lg_event->_messages));
-			$this->assertEquals(0, count($lg_norm->_messages));
-			$this->assertEquals(4, count($lg_consume->_messages));
+			self::assertEquals(4, count($lg_nonevent->_messages));
+			self::assertEquals(3, count($lg_event->_messages));
+			self::assertEquals(0, count($lg_norm->_messages));
+			self::assertEquals(4, count($lg_consume->_messages));
 
 			return;
 		}

--- a/Tests/Chain/ValidityTest.php
+++ b/Tests/Chain/ValidityTest.php
@@ -39,7 +39,9 @@
 			$chainHelper = new ChainHelper();
 			$chainHelper->linkNode(new InvalidNode())->linkNode(new ValidNode());
 
-			$this->assertCount(1, $chainHelper->getNodeList());
+			self::assertCount(1, $chainHelper->getNodeList());
+
+			return;
 		}
 
 		public function test_invalidDispatchFails() {
@@ -49,7 +51,9 @@
 			$dispatch      = new InvalidDispatch();
 			$shouldBeFalse = $chainHelper->traverse($dispatch);
 
-			$this->assertFalse($shouldBeFalse);
+			self::assertFalse($shouldBeFalse);
+
+			return;
 		}
 
 		public function test_validDispatchAndValidNodePasses() {
@@ -61,6 +65,8 @@
 
 			$shouldBeTrue = $chainHelper->traverse($dispatch);
 
-			$this->assertTrue($shouldBeTrue);
+			self::assertTrue($shouldBeTrue);
+
+			return;
 		}
 	}

--- a/Tests/Utilities/ReturnHelperTest.php
+++ b/Tests/Utilities/ReturnHelperTest.php
@@ -6,6 +6,44 @@
 	use Stoic\Utilities\ReturnHelper;
 
 	class ReturnHelperTest extends TestCase {
+		public function test_MessageHandling() {
+			$ret = new ReturnHelper();
+			self::assertEquals(0, count($ret->getMessages()), "ReturnHelper returns the correct number of messages");
+			self::assertFalse($ret->hasMessages(), "ReturnHelper notes absence of messages correctly");
+
+			$ret->addMessage("Testing");
+			self::assertEquals(1, count($ret->getMessages()), "ReturnHelper returns the correct number of messages");
+
+			$ret->addMessages(array(
+				"Testing2",
+				"Testing3"
+			));
+			self::assertEquals(3, count($ret->getMessages()), "ReturnHelper returns the correct number of messages");
+			self::assertTrue($ret->hasMessages(), "ReturnHelper notes presence of messages correctly");
+			self::assertArraySubset(array("Testing", "Testing2", "Testing3"), $ret->getMessages(), true, "ReturnHelper returns the correct messages");
+
+			return;
+		}
+
+		public function test_ResultHandling() {
+			$ret = new ReturnHelper();
+			self::assertEquals(0, count($ret->getResults()), "ReturnHelper returns the correct number of results");
+			self::assertFalse($ret->hasResults(), "ReturnHelper notes absence of results correctly");
+
+			$ret->addResult("Testing");
+			self::assertEquals(1, count($ret->getResults()), "ReturnHelper returns the correct number of results");
+
+			$ret->addResults(array(
+				"Testing2",
+				"Testing3"
+			));
+			self::assertEquals(3, count($ret->getResults()), "ReturnHelper returns the correct number of results");
+			self::assertTrue($ret->hasResults(), "ReturnHelper notes presence of results correctly");
+			self::assertArraySubset(array("Testing", "Testing2", "Testing3"), $ret->getResults(), true, "ReturnHelper returns the correct results");
+
+			return;
+		}
+
 		public function test_GoodVsBad() {
 			$ret = new ReturnHelper();
 			self::assertTrue($ret->isBad(), "ReturnHelper initializes as STATUS_BAD");

--- a/Tests/Utilities/ReturnHelperTest.php
+++ b/Tests/Utilities/ReturnHelperTest.php
@@ -1,0 +1,21 @@
+<?php
+
+	namespace Stoic\Utilities\Tests;
+
+	use PHPUnit\Framework\TestCase;
+	use Stoic\Utilities\ReturnHelper;
+
+	class ReturnHelperTest extends TestCase {
+		public function test_GoodVsBad() {
+			$ret = new ReturnHelper();
+			self::assertTrue($ret->isBad(), "ReturnHelper initializes as STATUS_BAD");
+
+			$ret->makeGood();
+			self::assertTrue($ret->isGood(), "ReturnHelper is made STATUS_GOOD");
+
+			$ret->makeBad();
+			self::assertTrue($ret->isBad(), "ReturnHelper is made STATUS_BAD");
+
+			return;
+		}
+	}

--- a/Utilities/ReturnHelper.php
+++ b/Utilities/ReturnHelper.php
@@ -1,0 +1,184 @@
+<?php
+
+	namespace Stoic\Utilities;
+
+	/**
+	 * Class to provide more data for
+	 * method/function returns.
+	 * 
+	 * @package Stoic\Utilities
+	 * @version 1.0.0
+	 */
+	class ReturnHelper {
+		/**
+		 * Array of messages in this return.
+		 * 
+		 * @var string[]
+		 */
+		protected $_messages;
+		/**
+		 * Array of results in this return.
+		 * 
+		 * @var mixed[]
+		 */
+		protected $_results;
+		/**
+		 * Current status of this return.
+		 * 
+		 * @var integer
+		 */
+		protected $_status;
+
+
+		const STATUS_BAD = 0;
+		const STATUS_GOOD = 1;
+
+
+		/**
+		 * Instantiates a new ReturnHelper class. Default
+		 * status is STATUS_BAD.
+		 */
+		public function __construct() {
+			$this->_messages = array();
+			$this->_results = array();
+			$this->_status = self::STATUS_BAD;
+
+			return;
+		}
+
+		/**
+		 * Adds a message onto the internal collection.
+		 * 
+		 * @param string $message String value of message to add to collection.
+		 */
+		public function addMessage($message) {
+			$this->_messages[] = $message;
+
+			return;
+		}
+
+		/**
+		 * Adds a group of messages onto the internal
+		 * collection.
+		 * 
+		 * @param string[] $messages Array of strings to add to collection.
+		 * @throws \InvalidArgumentException Thrown if null or empty array provided.
+		 */
+		public function addMessages(array $messages) {
+			if ($messages === null || count($messages) < 1) {
+				throw new \InvalidArgumentException("Messages array to ReturnHelper::addMessages() must be array with elements");
+			}
+
+			foreach (array_values($messages) as $msg) {
+				$this->_messages[] = $msg;
+			}
+
+			return;
+		}
+
+		/**
+		 * Adds a result onto the internal collection.
+		 * 
+		 * @param mixed $result Result value to add to collection.
+		 */
+		public function addResult($result) {
+			$this->_results[] = $result;
+
+			return;
+		}
+
+		/**
+		 * Adds a group of results onto the internal
+		 * collection.
+		 * 
+		 * @param mixed[] $results Array of results to add to collection.
+		 * @throws \InvalidArgumentException Thrown if null or empty array provided.
+		 */
+		public function addResults(array $results) {
+			if ($results === null || count($results) < 1) {
+				throw new \InvalidArgumentException("Results array to ReturnHelper::addResults() must be array with elements");
+			}
+
+			foreach (array_values($results) as $res) {
+				$this->_results[] = $res;
+			}
+
+			return;
+		}
+
+		/**
+		 * Returns TRUE if the current internal status
+		 * is set to STATUS_BAD.
+		 * 
+		 * @return boolean
+		 */
+		public function isBad() {
+			return $this->_status === self::STATUS_BAD;
+		}
+
+		/**
+		 * Returns TRUE if the current internal status
+		 * is set to STATUS_GOOD.
+		 * 
+		 * @return boolean
+		 */
+		public function isGood() {
+			return $this->_status === self::STATUS_GOOD;
+		}
+
+		/**
+		 * Returns the internal collection of messages.
+		 * 
+		 * @return string[]
+		 */
+		public function getMessages() {
+			return $this->_messages;
+		}
+
+		/**
+		 * Returns the internal collection of results.
+		 * 
+		 * @return mixed[]
+		 */
+		public function getResults() {
+			return $this->_results;
+		}
+
+		/**
+		 * Returns TRUE if there are messages stored in
+		 * the internal collection.
+		 * 
+		 * @return boolean
+		 */
+		public function hasMessages() {
+			return count($this->_messages) > 0;
+		}
+
+		/**
+		 * Returns TRUE if there are results stored in
+		 * the internal collection.
+		 * 
+		 * @return boolean
+		 */
+		public function hasResults() {
+			return count($this->_results) > 0;
+		}
+
+		/**
+		 * Sets the internal status as STATUS_BAD.
+		 */
+		public function makeBad() {
+			$this->_status = self::STATUS_BAD;
+
+			return;
+		}
+
+		/**
+		 * Sets the internal status as STATUS_GOOD.
+		 */
+		public function makeGood() {
+			$this->_status = self::STATUS_GOOD;
+
+			return;
+		}
+	}

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,12 @@
 	"homepage": "https://stoic-framework.com",
 	"autoload": {
 		"psr-0": {
-			"Stoic\\Chain\\": "./Chain"
+			"Stoic\\Chain\\": "./Chain",
+			"Stoic\\Utilities\\":  "./Utilities"
 		},
 		"psr-4": {
-			"Stoic\\Chain\\": "./Chain"
+			"Stoic\\Chain\\": "./Chain",
+			"Stoic\\Utilities\\":  "./Utilities"
 		},
 		"exclude-from-classmap": [
 			"/Tests/"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,5 +13,8 @@
 		<testsuite name="Stoic Chain Tests">
 			<directory suffix="Test.php">./Tests/Chain/</directory>
 		</testsuite>
+		<testsuite name="Stoic Utility Tests">
+			<directory suffix="Test.php">./Tests/Utilities/</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
Added a `ReturnHelper` class that follows the naming conventions set forth for toggle methods in the `DispatchBase` class.  Also switched all tests to use `self::assert*` for consistency.