### PR TITLE
Guarding microtime() Call in Log Messages

### DIFF
--- a/Log/Message.php
+++ b/Log/Message.php
@@ -65,13 +65,8 @@
 			$this->level = $level;
 			$this->message = $message;
 
-			$timeParts = explode('.', microtime(true));
-
-			if (count($timeParts) != 2) {
-				$timeParts[1] = 0;
-			}
-
-			$this->timestamp = new \DateTimeImmutable(date('Y-m-d G:i:s.', $timeParts[0]) . $timeParts[1], new \DateTimeZone('UTC'));
+			$timeParts = gettimeofday();
+			$this->timestamp = new \DateTimeImmutable(date('Y-m-d G:i:s.', $timeParts['sec']) . $timeParts['usec'], new \DateTimeZone('UTC'));
 
 			return;
 		}

--- a/Log/Message.php
+++ b/Log/Message.php
@@ -55,17 +55,22 @@
 		 * 
 		 * @param string $level String value of message level.
 		 * @param string $message String value of log message.
-		 * @throws InvalidArgumentException Thrown if invalid log level provided.
+		 * @throws \InvalidArgumentException Thrown if invalid log level provided.
 		 */
 		public function __construct($level, $message) {
 			if (array_key_exists($level, self::$validLevels) === false) {
-				throw new InvalidArgumentException("Invalid log level provided to Stoic\Log\LogMessage: {$level}");
+				throw new \InvalidArgumentException("Invalid log level provided to Stoic\Log\LogMessage: {$level}");
 			}
 
 			$this->level = $level;
 			$this->message = $message;
 
 			$timeParts = explode('.', microtime(true));
+
+			if (count($timeParts) != 2) {
+				$timeParts[1] = 0;
+			}
+
 			$this->timestamp = new \DateTimeImmutable(date('Y-m-d G:i:s.', $timeParts[0]) . $timeParts[1], new \DateTimeZone('UTC'));
 
 			return;

--- a/Log/NullAppender.php
+++ b/Log/NullAppender.php
@@ -12,6 +12,18 @@
 	 */
 	class NullAppender extends AppenderBase {
 		/**
+		 * Instantiates a new NullAppender object.
+		 *
+		 * @codeCoverageIgnore
+		 */
+		public function __construct() {
+			$this->setKey('NullAppender');
+			$this->setVersion('1.0.0');
+
+			return;
+		}
+
+		/**
 		 * Append method which simply consumes the collection
 		 * of log messages and returns without caring.
 		 * 

--- a/Tests/Log/LoggerTest.php
+++ b/Tests/Log/LoggerTest.php
@@ -44,7 +44,7 @@
 			try {
 				$msg = new Message('nonexistent-level', 'testing');
 				self::assertTrue(false);
-			} catch (\Psr\Log\InvalidArgumentException $ex) {
+			} catch (\InvalidArgumentException $ex) {
 				self::assertEquals("Invalid log level provided to Stoic\Log\LogMessage: nonexistent-level", $ex->getMessage());
 			}
 


### PR DESCRIPTION
Looks like from time to time calls to `explode('.', microtime(true))` weren't producing a decimal place and thus the following line would barf when accessing the `[1]` offset that would be the decimal place.  Added a guard for this instance and simply assumed `'0'` when a decimal place is missing (would be equivalent).  Also made a quick adjustment to be sure that the correct global `InvalidArgumentException` type was being thrown in the `Stoic\Log\Message` constructor.

- [#7] Adding guard in case microtime() didn't have a decimal place to split (assuming '0' as micro timing in that case)
- [#7] Fixing exception trigger in LoggerTest