### PR TITLE
Various Logger/Enum Improvements

### DIFF
--- a/Docs/Utilities/enum-helper.md
+++ b/Docs/Utilities/enum-helper.md
@@ -51,4 +51,5 @@ implemented.
 - [public] `getName()` -> Retrieves the set name for the object
 - [public] `getValue()` -> Retrieves the set value for the object
 - [public] `is($value)` -> Determines if the set value for the object is the same as the supplied value
+- [public] `isIn(...$values)` -> Determines if the current value is equal to any of the supplied values
 - [public] `jsonSerialize()` -> Serializes the object to its string representation

--- a/Docs/Utilities/enum-helper.md
+++ b/Docs/Utilities/enum-helper.md
@@ -41,6 +41,7 @@ implemented.
 ### Static Methods
 - [public] `fromString($string, $serializeAsName)` -> Returns a new Enum object using the name instead of the value for initialization
 - [public] `getConstList()` -> Returns the const lookup for the called class
+- [public] `tryGetEnum($value, $className)` -> Returns an EnumBase object of the type `$className`, either using an existing instance given to `$value` or using a valid integer given to `$value`
 - [public] `validName($name)` -> Validates a name against the const lookup values for the called class
 - [public] `validValue($value)` -> Validates a value against the const lookup values for the called class
 

--- a/Log/Logger.php
+++ b/Log/Logger.php
@@ -126,6 +126,8 @@
 					} else {
 						$replacements[$rkey] = "[object " . get_class($val) . "]";
 					}
+				} else if (is_array($val)) {
+					$replacements[$rkey] = "[" . print_r($val, true) . "]";
 				} else {
 					$replacements[$rkey] = "[" . gettype($val) . "]";
 				}

--- a/Tests/Log/LoggerTest.php
+++ b/Tests/Log/LoggerTest.php
@@ -170,43 +170,57 @@
 			$log->addAppender($app);
 			$log->output();
 
-			$log->info('Testing the way we {replace} strings.', array('replace' => 'REPLACE'));
+			$log->info('Testing the way we {replace} strings.', ['replace' => 'REPLACE']);
 			$log->output();
 
 			self::assertEquals('Testing the way we REPLACE strings.', $app->messages[0]->message);
-			$app->messages = array();
+			$app->messages = [];
 
 			$ex = new \Exception('Testing');
-			$log->info('{exception}', array('exception' => $ex));
+			$log->info('{exception}', ['exception' => $ex]);
 			$log->output();
 
 			self::assertEquals("[exception Exception]\n\tMessage: Testing\n\tStack Trace: {$ex->getTraceAsString()}", $app->messages[0]->message);
-			$app->messages = array();
+			$app->messages = [];
 
-			$log->info('{obj}', array('obj' => new TestContextClassWithToString()));
+			$log->info('{obj}', ['obj' => new TestContextClassWithToString()]);
 			$log->output();
 
 			self::assertEquals("TestContextClass: 5", $app->messages[0]->message);
-			$app->messages = array();
+			$app->messages = [];
 
 			$now = new \DateTime('now', new \DateTimeZone('UTC'));
-			$log->info('{date}', array('date' => $now));
+			$log->info('{date}', ['date' => $now]);
 			$log->output();
 
 			self::assertEquals($now->format(\DateTime::RFC3339), $app->messages[0]->message);
-			$app->messages = array();
+			$app->messages = [];
 
-			$log->info('{obj}', array('obj' => new TestContextClassWithoutToString()));
+			$log->info('{obj}', ['obj' => new TestContextClassWithoutToString()]);
 			$log->output();
 
 			self::assertEquals('[object Stoic\Log\Tests\TestContextClassWithoutToString]', $app->messages[0]->message);
-			$app->messages = array();
+			$app->messages = [];
 
-			$log->info('{obj}', array('obj' => null));
+			$log->info('{obj}', ['obj' => null]);
 			$log->output();
 
 			self::assertEquals('null', $app->messages[0]->message);
-			$app->messages = array();
+			$app->messages = [];
+
+			$log->info('{arr}', ['arr' => ['test' => 'val']]);
+			$log->output();
+
+			self::assertEquals("[Array\n(\n    [test] => val\n)\n]", $app->messages[0]->message);
+			$app->messages = [];
+
+			$dh = opendir('./');
+			$log->info('{non-scalar}', ['non-scalar' => $dh]);
+			$log->output();
+			closedir($dh);
+
+			self::assertEquals('[resource]', $app->messages[0]->message);
+			$app->messages = [];
 
 			return;
 		}

--- a/Tests/Utilities/EnumBaseTest.php
+++ b/Tests/Utilities/EnumBaseTest.php
@@ -16,6 +16,10 @@
 		const FIRST_VALUE = 1;
 	}
 
+	class NotAnEnum {
+		const FIRST_VALUE = 1;
+	}
+
 	class EnumBaseTest extends TestCase {
 		public function test_Instantiation() {
 			$val = new AnEnum(AnEnum::FIRST_VALUE);
@@ -49,6 +53,29 @@
 
 			$val = new AnEnum(AnEnum::FIRST_VALUE, false);
 			self::assertEquals('"1"', json_encode($val));
+
+			return;
+		}
+
+		public function test_TryGetEnum() {
+			$enum = EnumBase::tryGetEnum(1, AnotherEnum::class);
+			self::assertTrue($enum->getValue() == 1);
+
+			$enum = EnumBase::tryGetEnum(new AnotherEnum(1), AnotherEnum::class);
+			self::assertTrue($enum->getValue() == 1);
+
+			$enum = EnumBase::tryGetEnum(35, AnotherEnum::class);
+			self::assertTrue($enum->getValue() === null);
+
+			$enum = EnumBase::tryGetEnum(null, AnotherEnum::class);
+			self::assertTrue($enum->getValue() === null);
+
+			try {
+				$enum = EnumBase::tryGetEnum(1, NotAnEnum::class);
+				self::assertTrue(false);
+			} catch (\InvalidArgumentException $ex) {
+				self::assertEquals("Cannot attempt to retrieve an enum from a class that doesn't extend EnumBase", $ex->getMessage());
+			}
 
 			return;
 		}

--- a/Tests/Utilities/EnumBaseTest.php
+++ b/Tests/Utilities/EnumBaseTest.php
@@ -79,4 +79,15 @@
 
 			return;
 		}
+
+		public function test_IsIn() {
+			$enum = new AnotherEnum();
+			self::assertFalse($enum->isIn(1, 2));
+
+			$enum = new AnotherEnum(AnotherEnum::FIRST_VALUE);
+			self::assertTrue($enum->isIn(1));
+			self::assertFalse($enum->isIn(2));
+
+			return;
+		}
 	}

--- a/Utilities/EnumBase.php
+++ b/Utilities/EnumBase.php
@@ -216,6 +216,27 @@
 		}
 
 		/**
+		 * Determines if the current value is equal to any of the
+		 * supplied values.
+		 *
+		 * @param integer[] $values Array of integer values to compare against current value.
+		 * @return boolean
+		 */
+		public function isIn(int ...$values) {
+			if ($this->value === null) {
+				return false;
+			}
+
+			foreach (array_values($values) as $val) {
+				if ($this->value === $val) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
 		 * Serializes Enum object to its string representation.
 		 *
 		 * @return string

--- a/Utilities/EnumBase.php
+++ b/Utilities/EnumBase.php
@@ -89,6 +89,39 @@
 		}
 
 		/**
+		 * Attempts to instantiate an EnumBase class based on the given
+		 * value.  If the value is already the requested class, it is
+		 * returned.  If the value is a valid value for the class, a new
+		 * instance of the class with the value assigned is returned.  In
+		 * all other cases a blank instance of the requested class is
+		 * returned.
+		 *
+		 * @param integer|object $value The value which may or may not be valid as an enum class/value.
+		 * @param string $className Fully qualified class name to return.
+		 * @throws \InvalidArgumentException
+		 * @return EnumBase
+		 */
+		public static function tryGetEnum($value, $className) {
+			if (!is_a($className, EnumBase::class, true)) {
+				throw new \InvalidArgumentException("Cannot attempt to retrieve an enum from a class that doesn't extend EnumBase");
+			}
+
+			if ($value === null) {
+				return new $className();
+			}
+
+			if (is_a($value, $className)) {
+				return $value;
+			}
+
+			if (!$className::validValue($value)) {
+				return new $className();
+			}
+
+			return new $className($value);
+		}
+
+		/**
 		 * Static method to validate a name against the Enum
 		 * object's possible constants.
 		 *


### PR DESCRIPTION
The important list:

* Brought all test coverage back up to 100%
* Added `EnumBase::tryGetEnum()` because that's code I rewrite constantly
* Added `EnumBase::isIn()` to make some common comparisons require less typing
* Added array interpolation to `Logger::interpolate()`